### PR TITLE
set unsescaping mode to UnescapingModeAllExceptSlash

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,6 +10,7 @@
     "protobuf",
     "protojson",
     "slok",
+    "Unescaping",
     "wrapf",
     "zerolog",
     "zpages"

--- a/service_factory.go
+++ b/service_factory.go
@@ -23,8 +23,7 @@ import (
 	"github.com/slok/go-http-metrics/middleware"
 )
 
-type ServiceFactory struct {
-}
+type ServiceFactory struct{}
 
 var mdlw middleware.Middleware
 
@@ -57,7 +56,6 @@ func (f *ServiceFactory) CreateService(
 	gatewayOpts *GatewayOptions,
 	cleanup ...func(),
 ) (*Server, error) {
-
 	grpcServer, err := prepareGrpcServer(&config.GRPC.Certs, grpcOpts.ServerOptions)
 	if err != nil {
 		return nil, err
@@ -90,7 +88,6 @@ func (f *ServiceFactory) CreateService(
 
 // prepareGateway provides a http server that will have the registrations pointed to the corresponding configured grpc server.
 func (f *ServiceFactory) prepareGateway(config *API, gatewayOpts *GatewayOptions) (Gateway, error) {
-
 	if len(config.Gateway.AllowedHeaders) == 0 {
 		config.Gateway.AllowedHeaders = DefaultGatewayAllowedHeaders
 	}
@@ -196,6 +193,7 @@ func (f *ServiceFactory) gatewayMux(allowedHeaders []string, errorHandler runtim
 				},
 			},
 		),
+		runtime.WithUnescapingMode(runtime.UnescapingModeAllExceptSlash),
 		runtime.WithForwardResponseOption(httpResponseModifier),
 	}
 


### PR DESCRIPTION
We need this in order to support path params that contain encoded forward slashes: https://github.com/grpc-ecosystem/grpc-gateway/blob/v2.20.0/runtime/mux.go#L33-L35

The following calls should not result in code 5, not found error:
```
curl 'https://localhost:9393/api/v3/directory/object/user/%2Ftodo' \
  -H 'accept: */*' \
  --insecure
```
```
curl 'https://localhost:9393/api/v3/directory/object/user/to%2Fdo' \
  -H 'accept: */*' \
  --insecure
```